### PR TITLE
Fix: 銘柄表示後、2-3分経過すると画面が閉じた扱いになってしまう対応

### DIFF
--- a/background.js
+++ b/background.js
@@ -34,17 +34,25 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
  * Preview UI
  **************/
 let tvTabId = null;
-chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+chrome.runtime.onMessage.addListener(async (msg, sender, sendResponse) => {
   if (msg.action !== "updateSymbol") return;
   let {ticker, theme, interval} = msg;
+  console.debug("Backend: ticker: " + ticker);
+  console.debug("Backend: theme: " + theme);
+  console.debug("Backend: interval: " + interval);
 
   // 新規tab作成の時は日足へリセット
   if (!tvTabId) {
     interval = "1D";
-    chrome.storage.local.set({
-      tv_interval: interval
-    });
+    chrome.storage.local.set({tv_interval: interval});
+    console.log("Backend: Interval save " + interval);
+
+    // ServiceWorkerが2-3分経過すると休止モードとなりグローバル変数をクリアしてしまうためLocalStorageから復元する.
+    const data = await chrome.storage.local.get("tvTabId");
+    tvTabId = data.tvTabId;
+    console.log("get TradingView tab id.");
   }
+
   const url = `https://jp.tradingview.com/chart/?symbol=${ticker}&interval=${interval}&theme=${theme}`;
   openOrUpdateTab(url, ticker);
 });
@@ -56,41 +64,14 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 function openOrUpdateTab(url, ticker) {
   // Window作成
   if (!tvTabId) {
-    chrome.windows.create({
-      url: url,
-      type: "normal",
-      focused: true
-    }, (win) => {
-      if (win.tabs && win.tabs.length > 0) {
-        tvTabId = win.tabs[0].id;
-      } else {
-        // win.tabs が空だった場合のフォールバック
-        chrome.tabs.query({ windowId: win.id, active: true }, (tabs) => {
-          tvTabId = tabs[0].id;
-          console.log("Tab ID acquired via query:", tvTabId);
-        });
-      }
-    });
+    createNewWindow(url)
     return;
   }
 
   chrome.tabs.get(tvTabId, (tab) => {
-    if (chrome.runtime.lastError) {
-      chrome.windows.create({
-        url: url,
-        type: "normal",
-        focused: true
-      }, (win) => {
-        if (win.tabs && win.tabs.length > 0) {
-          tvTabId = win.tabs[0].id;
-        } else {
-          // win.tabs が空だった場合のフォールバック
-          chrome.tabs.query({ windowId: win.id, active: true }, (tabs) => {
-            tvTabId = tabs[0].id;
-            console.log("Tab ID acquired via query:", tvTabId);
-          });
-        }
-    });
+    // タブが消えている場合は新規作成
+    if (chrome.runtime.lastError || !tab) {
+      createNewWindow(url)
       return;
     }
 
@@ -109,10 +90,36 @@ function openOrUpdateTab(url, ticker) {
 
 
 /**************
+ * Window作成
+ **************/
+function createNewWindow(url) {
+  chrome.windows.create({ url, type: "normal", focused: true }, (win) => {
+    tvTabId = win.tabs[0].id;
+    // 次回の起動（2-3分後）のためにストレージにバックアップ
+    chrome.storage.local.set({ tvTabId: tvTabId });
+    console.log("Backend: Saved Managed Tradingview TabId to storage.");
+  });
+}
+
+
+/**************
  * Close Tab
  **************/
 chrome.tabs.onRemoved.addListener((tabId) => {
   if (tabId === tvTabId) {
     tvTabId = null;
+    chrome.storage.local.remove("tvTabId");
+    console.log("Backend: Managed TradingView tab closed.");
+
+  }else{
+    // メモリが空(=ServiceWorkerが休止中）の場合、ストレージを確認する。
+    // 管理しているTabIDであればCleanUpする。
+    chrome.storage.local.get("tvTabId", (data) => {
+      if (data.tvTabId === tabId) {
+        chrome.storage.local.remove("tvTabId");
+        console.log("Backend: Managed TradingView tab closed (detected from storage).");
+      }
+    });
   }
+
 });

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "日本株/米国株 銘柄チェッカー",
-  "version": "0.3",
+  "version": "0.3.1",
   "description": "Cleartradeで利用する銘柄チェッカー。日本株/米国株向けです。",
   "icons": {
     "16": "icons/icon16.png",


### PR DESCRIPTION
## 概要
バグ修正。
Peak Finderで銘柄検索後、2-3分放置。
その後再検索するとwindowが再生成されてTradingViewが複数見える不具合の修正。

## 原因
Chrome拡張機能の仕様。
Chromeを2-3分放置しておくと、メモリ節約のためにServiceworker(backend.js)が停止する。
その際にGlobal変数で持っていたTvTabIdがクリアされてnullになる。
↓
再復帰した際に、タブ無しの判定となってしまい新たなウィンドウが生成された。

## 対応
Chrome LocalStorageへタブIDを保存する実装へ変更した。
で、読み出し時にタブIDが無い場合はLocalStorageからタブIDを取得してそのタブが有るかチェックさせるようにした。