### PR TITLE
Fix: Mac環境でカーソル移動に支障が出る対応(#3), ウィンドウが不用意に二重作成される場合があるため修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ JP/US Stock Checker for PeakFinder
 https://github.com/ogalush/jp_us_stock_extension/archive/refs/heads/main.zip  
 → ダウンロード後、zipファイルを解凍する。  
 
-2. 拡張機能を入れる
+2. 拡張機能を入れる  
+2.1 拡張機能を入れる (Developer版)  
 ```
 Chrome 拡張のインストール方法:
 1. chrome://extensions/ を開く
@@ -17,6 +18,11 @@ Chrome 拡張のインストール方法:
 4. ダウンロードした「jp_us_stock_extension」フォルダを選択する。
 5. 拡張機能ウィンドウに「日本株/米国株 銘柄チェッカー」が表示されればOK.
 ```
+  
+2.2 拡張機能を入れる (一般ユーザ版)  
+「[日本株/米国株 銘柄チェッカー](https://chromewebstore.google.com/detail/%E6%97%A5%E6%9C%AC%E6%A0%AA%E7%B1%B3%E5%9B%BD%E6%A0%AA-%E9%8A%98%E6%9F%84%E3%83%81%E3%82%A7%E3%83%83%E3%82%AB%E3%83%BC/jajcbbhfdckikdhpgfjdaedndiolelkp?authuser=0&hl=ja)」をダウンロードしてください。  
+画面右上の「Chrome に追加」→「拡張機能を追加」を押せばインストール完了です。  
+  
 3. PeakFinderで銘柄を取得する  
 4. 「右クリック」→ 「日米銘柄をマーキングする」を押す。  
 <img width="206" height="433" alt="image" src="https://github.com/user-attachments/assets/90a8e8b0-ff24-4248-9d41-fb6378a914a1" />  
@@ -88,4 +94,13 @@ $ git push origin ${VER:?}
 ```
 $ git push origin --delete ${VER:?}
 ```
+
+## コードの役割について
+|Key|Value|
+|---|---|
+|manifest.json|GoogleChrome拡張機能の構成・権限を定義する設定ファイル|
+|background.js|Service Worker。拡張機能のバックグラウンド処理を担当|
+|contents.js|閲覧サイト（PeakFinder）で動作。銘柄コードの抽出とメッセージ送信を担当|
+|tradingview.js|TradingView内で動作。銘柄切り替えの高速化とチャート設定（日足等）の保持を担当|
+  
 以上

--- a/content.js
+++ b/content.js
@@ -8,8 +8,8 @@
  *  - Hover stock symbol to preview TradingView chart
  *
  * Author: Takehiko OGASAWARA
- * Version: 0.3
- * Last Updated: 2026-03-14
+ * Version: 0.3.2
+ * Last Updated: 2026-03-15
  */
 
 /**************
@@ -28,7 +28,6 @@ function markDataSymbol() {
 
     td.classList.add("stock-marker");
     td.dataset.ticker = ticker;
-    td.style.cursor = "text";
     td.style.backgroundColor = "#fff3b0"; // 薄い黄色
     td.style.fontWeight = "bold";
   });
@@ -51,6 +50,7 @@ async function showPreview(ticker) {
   });
 }
 
+
 /**************
  * for copy & Paste stock-codes.
  **************/
@@ -71,10 +71,29 @@ function getClosestStockMarker(target) {
 let hoverTimer = null;
 document.addEventListener("mouseenter", (e) => {
   const el = getClosestStockMarker(e.target);
+
+  // 新しい要素に入ったら、既存のタイマー(表示予約)をクリアする
+  if (hoverTimer) {
+    clearTimeout(hoverTimer);
+    hoverTimer = null;
+  }
+
   if (!el) return;
   hoverTimer = setTimeout(() => {
     showPreview(el.dataset.ticker);
   }, 120);
+}, true);
+
+
+/**************
+ * MouseLeave
+ **************/
+document.addEventListener("mouseleave", (e) => {
+  // 要素から外れた時もタイマーを止める(銘柄表示のタイマー予約が入っている場合はキャンセルする)
+  if (getClosestStockMarker(e.target)) {
+    clearTimeout(hoverTimer);
+    hoverTimer = null;
+  }
 }, true);
 
 
@@ -89,6 +108,7 @@ function getTheme() {
   return isDarkMode() ? "dark" : "light";
 }
 
+
 /**************
  * 足取得
  **************/
@@ -102,85 +122,12 @@ function getInterval() {
 
 
 /**************
- * Style
- **************/
-const style = document.createElement("style");
-style.textContent = `
-#stock-preview {
-  position: fixed;
-  top: 80px;
-  left: 500px;
-  width: 420px;
-  height: 360px;
-  background: #fff;
-  border: 1px solid #ccc;
-  box-shadow: 0 4px 16px rgba(0,0,0,.3);
-  z-index: 999999;
-  display: flex;
-  flex-direction: column;
-  pointer-events: auto;
-}
-
-#stock-preview .header {
-  height: 32px;
-  background: #f5f5f5;
-  cursor: move;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 8px;
-  font-size: 12px;
-  user-select: none;
-}
-
-#stock-preview iframe {
-  flex: 1;
-  border: none;
-}
-
-#stock-preview .close {
-  background: none;
-  border: none;
-  font-size: 16px;
-  cursor: pointer;
-}
-
-#stock-preview .resize-handle {
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  width: 16px;
-  height: 16px;
-  cursor: nwse-resize;
-}
-
-.stock-marker {
-  user-select: text;
-  cursor: text;
-}
-`;
-
-// DarkMode対応
-const dark = isDarkMode();
-style.textContent += dark ? `
-#stock-preview {
-  background: #1e1e1e;
-  border-color: #444;
-  color: #ddd;
-}
-#stock-preview .header {
-  background: #2b2b2b;
-}
-` : "";
-document.head.appendChild(style);
-
-
-/**************
  * initialize
  **************/
 function initMarking() {
   markDataSymbol();
 }
+
 
 /**************
  * Main

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "日本株/米国株 銘柄チェッカー",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Cleartradeで利用する銘柄チェッカー。日本株/米国株向けです。",
   "icons": {
     "16": "icons/icon16.png",


### PR DESCRIPTION
Fixes: #3 

## 概要
* Macで銘柄検索してTradingViewを表示させようとすると表が意図せず動くというご報告の修正。
* TradingViewで素早く初回の銘柄選択をすると、ウィンドウが二重表示となるパターンが見られたので、タイマーリセット(二重になった時に前の方の表示をキャンセルさせる）を入れて軽減させる対応

## 原因
今の所はっきりしたところは不明。

## 対応
上記2点の不具合に関しては確実にこれというのがまだ分からないため、考えられるところを削除するような形で進める。
* 前作の「米国銘柄チェッカー」の際にiframeを使用していてそのStyleが残っているのでこれの可能性？
原因特定まで至らなかったが、不要なStyleが要因になっている可能性を考慮して削除した。
* ウィンドウの二重表示は条件が重ならないと発生しないので保険でClearTimerを入れた。

という感じで原因と対策がまだふわっとしているので修正をリリースしてから様子を見る方向。


## 動作確認
PeakFinder→TradingViewへ通常通り正常表示することを確認。
