### PR TITLE
Feature: 銘柄投票システム対応(投票画面, 投票結果画面)

### DIFF
--- a/background.js
+++ b/background.js
@@ -8,8 +8,8 @@
  *  - Hover stock symbol to preview TradingView chart
  *
  * Author: Takehiko OGASAWARA
- * Version: 0.3
- * Last Updated: 2026-03-14
+ * Version: 0.4.0
+ * Last Updated: 2026-03-20
  */
 
 chrome.runtime.onInstalled.addListener(() => {
@@ -24,7 +24,7 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
   if (info.menuItemId === "mark-stocks") {
     chrome.scripting.executeScript({
       target: { tabId: tab.id },
-      files: ["content.js"]
+      files: ["siteConfigs.js", "content.js"]
     });
   }
 });

--- a/content.js
+++ b/content.js
@@ -8,29 +8,46 @@
  *  - Hover stock symbol to preview TradingView chart
  *
  * Author: Takehiko OGASAWARA
- * Version: 0.3.2
- * Last Updated: 2026-03-15
+ * Version: 0.4.0
+ * Last Updated: 2026-03-20
  */
 
 /**************
  * MarkUp stock-code
  **************/
 function markDataSymbol() {
-  document.querySelectorAll("tr[data-symbol]").forEach(tr => {
-    const ticker = tr.dataset.symbol;
-    if (!ticker) return;
+  const SITE_CONFIGS = window.STOCK_MARKER.SITE_CONFIGS;
+  for (const config of SITE_CONFIGS) {
+    const elements = document.querySelectorAll(config.selector);
+    if (elements.length === 0) continue;
 
-    const td = tr.querySelector("td");
-    if (!td) return;
+    let found = false;
+    for (const el of elements) {
+      const code = config.getCode(el);
+      if (!code) continue;
 
-    // 二重処理防止
-    if (td.classList.contains("stock-marker")) return;
+      const target = config.target(el);
+      if (!target) continue;
 
-    td.classList.add("stock-marker");
-    td.dataset.ticker = ticker;
-    td.style.backgroundColor = "#fff3b0"; // 薄い黄色
-    td.style.fontWeight = "bold";
-  });
+      // 二重処理防止
+      if (target.classList.contains("stock-marker")) continue;
+
+      target.classList.add("stock-marker");
+      target.dataset.ticker = code;
+      if (config.applyStyle) {
+        config.applyStyle(target);
+      } else {
+        target.style.color = "#000000"; // 黒色 (ダークモード時に白色 vs 黄色(背景)のため指定)
+        target.style.backgroundColor = "#fff3b0"; // 黄色
+        target.style.fontWeight = "bold";
+      }
+
+      // CONFIGが合っているとみなして終了.
+      found = true;
+    }
+
+    if (found) break;
+  }
 }
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "日本株/米国株 銘柄チェッカー",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Cleartradeで利用する銘柄チェッカー。日本株/米国株向けです。",
   "icons": {
     "16": "icons/icon16.png",

--- a/siteConfigs.js
+++ b/siteConfigs.js
@@ -1,0 +1,38 @@
+window.STOCK_MARKER = window.STOCK_MARKER || {};
+window.STOCK_MARKER.SITE_CONFIGS = [
+  {
+    name: "PeakFinder",
+    selector: "tr[data-symbol]",
+    getCode: el => el.dataset.symbol,
+    target: el => el.querySelector("td"),
+    applyStyle: (target) => {
+      target.style.color = "#000000"; // 黒色 (ダークモード時に白色 vs 黄色(背景)のため指定)
+      target.style.backgroundColor = "#fff3b0"; // 黄色
+      target.style.fontWeight = "bold";
+    }
+  },
+  {
+    name: "discover-stocks_vote",
+    selector: 'input[type="checkbox"][aria-label]',
+    getCode: el => el.getAttribute("aria-label"),
+    target: el => el.closest('[data-testid="stCheckbox"]'), 
+    applyStyle: (target) => {
+      // チェックボックスの文字がpタグ
+      const p = target.querySelector('[data-testid="stMarkdownContainer"] p');
+      if (p) {
+        p.style.color = "#000000"; // 黒色 (ダークモード時に白色 vs 黄色(背景)のため指定)
+      }
+      target.style.backgroundColor = "#fff3b0"; // 黄色
+    }
+  },
+  {
+    name: "discover-stocks_result",
+    selector: "[data-stock-code]",
+    getCode: el => el.dataset.stockCode,
+    target: el => el,
+    applyStyle: (target) => {
+      target.style.color = "#000000"; // 黒色 (ダークモード時に白色 vs 黄色(背景)のため指定)
+      target.style.backgroundColor = "#fff3b0"; // 黄色
+    }
+  }
+];


### PR DESCRIPTION
Closes #5

## 概要
「日本株/米国株銘柄チェッカー」を「銘柄投票」に対応します。

対応画面は
* PeakFinder:  日本株
* PeakFinder:  米国株
* 銘柄投票: 投票画面 (New)
* 銘柄投票: 投票結果画面 (New)

になる見込みです。

画面それぞれに銘柄コードへの対応が異なるためスタイル設定を設定ファイルへ切り出しました。

## 関連PR
* https://github.com/kita-develop/discover-stocks/pull/35

## 動作確認
PeakFinderおよび銘柄投票の銘柄コードを拾える事を確認。

### 効果確認
* 銘柄投票: 投票画面
銘柄コードを検知してURLを開く事を確認。
併せて、チェックマークもつけて投票出来ることも確認済み。（画面省略）
<img width="823" height="335" alt="image" src="https://github.com/user-attachments/assets/27ccc79e-b87b-490d-a37a-3a0fc10d7c62" />

* 銘柄投票: 投票結果画面
https://github.com/kita-develop/discover-stocks/pull/35
の修正内容が入っている状態で銘柄コード検知して、画面が開く事を確認。
<img width="530" height="326" alt="image" src="https://github.com/user-attachments/assets/0600799c-7c8b-4b12-9dd5-b28d75ef3f98" />

### 正常動作
* PeakFinder (日本株)
銘柄コードを検知してURLを開く事を確認。
<img width="452" height="223" alt="image" src="https://github.com/user-attachments/assets/fa7f2c8a-9ce9-48a6-b6cb-10f5e954f0b2" />


* PeakFinder (米国株)
銘柄コードを検知してURLを開く事を確認。
<img width="378" height="290" alt="image" src="https://github.com/user-attachments/assets/112e88a5-8518-499a-8c62-725f8f1e4d44" />

