### PR TITLE
Feature: 他の株価上昇ランキングページ対応 (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,28 @@ $ git push origin --delete ${VER:?}
 
 ## 動作確認について
 銘柄コードの検知が出来ること、チェック出来た銘柄コードからTradingViewへ画面遷移出来ることの2点を確認する。  
-https://github.com/ogalush/jp_us_stock_extension/pull/6 で銘柄投票へ対応したため対象は以下となる。
+https://github.com/ogalush/jp_us_stock_extension/pull/6 で銘柄投票へ対応したため対象は以下となる。  
+(1) Require画面
 |Key|Value|
 |---|---|
 |PeakFinder: 日本株|-|
 |PeakFinder: 米国株|-|
 |銘柄投票: 投票画面|チェックマークをつけて投票も出来ること。|
 |銘柄投票: 投票結果画面|-|
+  
+(2) Optional画面  
+銘柄マーカーの利用範囲を広げるため一般のランキングサイトもある程度見られるようにする。  
+先方のWebサイト更改によりマーカー取得出来なくなることも容易に考えられるため、  
+table, divタグでの表を閲覧できるように対応する。(#8)
+|Key|Value|
+|---|---|
+|[SBI証券 値上がり率上位ランキング（日本株）](https://www.sbisec.co.jp/ETGate/?_ControlID=WPLETmgR001Control&_PageID=WPLETmgR001Mdtl20&_ActionID=DefaultAID&_DataStoreID=DSWPLETmgR001Control&OutSide=on&getFlg=on&burl=iris_ranking&cat1=market&cat2=ranking&file=index.html&dir=tl1-rnk%7Ctl2-stock%7Ctl3-price%7Ctl4-uprate%7Ctl5-priceview%7Ctl7-T1&_scpr=intpr=hn_i_ds_rank)|表の中の銘柄コードのマーキング・チャート表示|
+|[SBI証券 当社週間売買代金ランキング (米国株)](https://www.sbisec.co.jp/ETGate/?OutSide=on&getFlg=on&_ControlID=WPLETmgR001Control&_PageID=WPLETmgR001Mdtl20&_ActionID=DefaultAID&_DataStoreID=DSWPLETmgR001Control&burl=iris_ranking&cat1=market&cat2=ranking&dir=tl1-rnk%7Ctl2-foreign%7Ctl3-salesval&file=index.html)|〃|
+|[日経新聞 値上がり率ランキング (日本株)](https://www.nikkei.com/marketdata/ranking-jp/price-rise/)|〃|
+|[日経新聞 値上がり率ランキング (米国株)](https://www.nikkei.com/marketdata/ranking-us/price-rise/)|〃|
+|[KABUTAN 今日の株価上昇率ランキング (日本株)](https://kabutan.jp/warning/?mode=2_1&market=1&dispmode=normal)|〃|
+|[KABUTAN 今日の株価上昇率ランキング (米国株)](https://us.kabutan.jp/warnings/price_increase)|〃|
+|[moomoo証券 ランキング (日本株)](https://www.moomoo.com/ja/quote/jp/most-active-stocks)|〃|
+|[moomoo証券 ランキング (米国株)](https://www.moomoo.com/ja/quote/us/most-active-stocks)|〃|
 
 以上

--- a/content.js
+++ b/content.js
@@ -16,6 +16,7 @@
  * MarkUp stock-code
  **************/
 function markDataSymbol() {
+  let site_found = false;
   const SITE_CONFIGS = window.STOCK_MARKER.SITE_CONFIGS;
   for (const config of SITE_CONFIGS) {
     const elements = document.querySelectorAll(config.selector);
@@ -30,7 +31,10 @@ function markDataSymbol() {
       if (!target) continue;
 
       // 二重処理防止
-      if (target.classList.contains("stock-marker")) continue;
+      if (target.classList.contains("stock-marker")){
+        found = true;
+        continue;
+      }
 
       target.classList.add("stock-marker");
       target.dataset.ticker = code;
@@ -45,8 +49,99 @@ function markDataSymbol() {
       // CONFIGが合っているとみなして終了.
       found = true;
     }
+    if (found){
+      console.log("markDataSymbol ConfigSelector: " + config.name);
+      site_found = true;
+      break;
+    }
+  }
 
-    if (found) break;
+  // CONFIGが合っていないサイトの場合
+  if(!site_found){
+    console.log("markDataSymbol ConfigSelector: FallBackDetect");
+    // FallBack処理 (最後は正規表現でマッチングさせる)
+    fallbackDetect();
+  }
+}
+
+
+/**************
+* MarkUp stock-code fallback support (1)
+ **************/
+function fallbackDetect() {
+  const elements = document.querySelectorAll("table *, div *");
+
+  for (const el of elements) {
+    if (el.dataset.stockMarked) continue;
+
+    const text = el.textContent;
+    if (!text) continue;
+
+    const result = detectStockCode(text);
+    if (!result) continue;
+    console.debug("fallbackDetect TYPE:", result.type, "CODE:", result.code);
+
+    el.dataset.stockMarked = "true";
+
+    //銘柄コード部分をマーキング
+    highlightStockCode(el, result.code);
+  }
+}
+
+
+/**************
+* MarkUp stock-code fallback support (2)
+ **************/
+function detectStockCode(text) {
+  // 銘柄名+銘柄コードの場合の対応
+  const t = text.replace(/\s+/g, " ").trim();
+
+  // 日本株（部分一致）
+  const jpMatch = t.match(/\b\d{3}[0-9A-Z]\b/);
+  if (jpMatch) {
+    return { type: "JP", code: jpMatch[0] };
+  }
+
+  // 米国株
+  const usMatch = t.match(/\b[A-Z]{1,5}([.-][A-Z])?\b/);
+  if (usMatch) {
+    const code = usMatch[0];
+    if (["USD", "ETF", "ADR", "PER", "EPS"].includes(code)) return null;
+    return { type: "US", code };
+  }
+  return null;
+}
+
+
+/**************
+* MarkUp stock-code fallback support (3)
+ **************/
+function highlightStockCode(el, code) {
+  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+  let node;
+  while (node = walker.nextNode()) {
+    if (!node.nodeValue.includes(code)) continue;
+
+    const span = document.createElement("span");
+    span.textContent = code;
+    span.style.backgroundColor = "#fff3b0";
+    span.style.color = "#000000";
+    span.style.fontWeight = "bold";
+    span.dataset.ticker = code; //TradingView用
+    span.classList.add("stock-marker"); //TradingView用
+
+    const parts = node.nodeValue.split(code);
+    const fragment = document.createDocumentFragment();
+
+    parts.forEach((part, index) => {
+      if (part) {
+        fragment.appendChild(document.createTextNode(part));
+      }
+      if (index < parts.length - 1) {
+        fragment.appendChild(span.cloneNode(true));
+      }
+    });
+    node.parentNode.replaceChild(fragment, node);
   }
 }
 
@@ -54,10 +149,11 @@ function markDataSymbol() {
 /**************
  * Show TradingView
  **************/
-let currentTicker = null;
 async function showPreview(ticker) {
-  if (currentTicker === ticker) return;
-  currentTicker = ticker;
+  const state = window.STOCK_MARKER.contentState;
+  if (state.currentTicker === ticker) return;
+  state.currentTicker = ticker;
+
   const interval = await getInterval();
   chrome.runtime.sendMessage({
     action: "updateSymbol",
@@ -85,18 +181,18 @@ function getClosestStockMarker(target) {
 /**************
  * MouceOver → TradingView Tab
  **************/
-let hoverTimer = null;
 document.addEventListener("mouseenter", (e) => {
   const el = getClosestStockMarker(e.target);
 
   // 新しい要素に入ったら、既存のタイマー(表示予約)をクリアする
-  if (hoverTimer) {
-    clearTimeout(hoverTimer);
-    hoverTimer = null;
+  const state = window.STOCK_MARKER.contentState;
+  if (state.hoverTimer) {
+    clearTimeout(state.hoverTimer);
+    state.hoverTimer = null;
   }
 
   if (!el) return;
-  hoverTimer = setTimeout(() => {
+  state.hoverTimer = setTimeout(() => {
     showPreview(el.dataset.ticker);
   }, 120);
 }, true);
@@ -106,10 +202,11 @@ document.addEventListener("mouseenter", (e) => {
  * MouseLeave
  **************/
 document.addEventListener("mouseleave", (e) => {
+  const state = window.STOCK_MARKER.contentState;
   // 要素から外れた時もタイマーを止める(銘柄表示のタイマー予約が入っている場合はキャンセルする)
   if (getClosestStockMarker(e.target)) {
-    clearTimeout(hoverTimer);
-    hoverTimer = null;
+    clearTimeout(state.hoverTimer);
+    state.hoverTimer = null;
   }
 }, true);
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "日本株/米国株 銘柄チェッカー",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Cleartradeで利用する銘柄チェッカー。日本株/米国株向けです。",
   "icons": {
     "16": "icons/icon16.png",

--- a/siteConfigs.js
+++ b/siteConfigs.js
@@ -1,4 +1,9 @@
-window.STOCK_MARKER = window.STOCK_MARKER || {};
+window.STOCK_MARKER = window.STOCK_MARKER || {
+  contentState: {
+    currentTicker: null,
+    hoverTimer: null
+  }
+};
 window.STOCK_MARKER.SITE_CONFIGS = [
   {
     name: "PeakFinder",


### PR DESCRIPTION
Closes: #7
## 概要
### Feature: 通常のサイト対応
PeakFinder, 銘柄投票以外にも、通常のサイトで対応可能なところを銘柄チェックできるようにする。

サイト毎にhtmlの実装がバラバラとなっているため、今のロジックを活かせる範囲で取得可能なところを取得していく。
いくつかのサイトを見たところ大まかに
* tableタグ
* divタグ

でランキングを表示しているためこれを取得する実装にしています。

不確実性が高いマッチングとなるため、
確実に検知したいRequire条件の「PeakFinder」と「銘柄投票」を検知させる実装と分離するようにします。

### Fix: グローバル変数のケア
銘柄チェックを同じ画面・ページで2回以上実行するとグローバル変数が再定義されるタイミングで「already exists」エラーとなった。
このためグローバル変数の初期設定をsiteConfigs.js の方に入れる変更を行なっている。


## 効果
一般的なサイトにある株を容易に探すことができる。

## 動作確認
Require画面
* PeakFinder: 日本株
<img width="365" height="251" alt="image" src="https://github.com/user-attachments/assets/3c046540-acc2-4b92-a410-5b294bad9a05" />

* PeakFinder: 米国株
<img width="220" height="153" alt="image" src="https://github.com/user-attachments/assets/4ed438b6-d6a6-48a6-a148-f89b67211c0c" />

* 銘柄投票: 投票画面
<img width="414" height="228" alt="image" src="https://github.com/user-attachments/assets/f3f1940b-5317-4694-a8a4-0e75d96a4b29" />

* 銘柄投票: 投票結果画面
<img width="291" height="175" alt="image" src="https://github.com/user-attachments/assets/233a18f3-6a33-4376-9964-bf7bad50482f" />

Optional画面
サイトの仕様が変わると容易に検知出来なくなるため、Optional画面としている。（＝NiceToHave）
* [SBI証券 値上がり率上位ランキング（日本株）](
https://www.sbisec.co.jp/ETGate/?_ControlID=WPLETmgR001Control&_PageID=WPLETmgR001Mdtl20&_ActionID=DefaultAID&_DataStoreID=DSWPLETmgR001Control&OutSide=on&getFlg=on&burl=iris_ranking&cat1=market&cat2=ranking&file=index.html&dir=tl1-rnk%7Ctl2-stock%7Ctl3-price%7Ctl4-uprate%7Ctl5-priceview%7Ctl7-T1&_scpr=intpr=hn_i_ds_rank)
<img width="343" height="344" alt="image" src="https://github.com/user-attachments/assets/22c69fb2-da17-4130-a93e-83175dfda4d6" />

* [SBI証券 当社週間売買代金ランキング (米国株)](https://www.sbisec.co.jp/ETGate/?OutSide=on&getFlg=on&_ControlID=WPLETmgR001Control&_PageID=WPLETmgR001Mdtl20&_ActionID=DefaultAID&_DataStoreID=DSWPLETmgR001Control&burl=iris_ranking&cat1=market&cat2=ranking&dir=tl1-rnk%7Ctl2-foreign%7Ctl3-salesval&file=index.html
)
<img width="315" height="380" alt="image" src="https://github.com/user-attachments/assets/3052d688-e40a-4185-9a14-21633ea8935f" />

* [日経新聞 値上がり率ランキング (日本株)](https://www.nikkei.com/marketdata/ranking-jp/price-rise/)
<img width="363" height="381" alt="image" src="https://github.com/user-attachments/assets/3575f6fa-f919-4096-be6a-16b37987aaf8" />

* [日経新聞 値上がり率ランキング (米国株)](https://www.nikkei.com/marketdata/ranking-us/price-rise/)
<img width="270" height="328" alt="image" src="https://github.com/user-attachments/assets/5e2e279f-954b-4d30-9fe3-e864b4d72e7a" />

* [KABUTAN 今日の株価上昇率ランキング (日本株)](https://kabutan.jp/warning/?mode=2_1&market=1&dispmode=normal)
<img width="300" height="335" alt="image" src="https://github.com/user-attachments/assets/74066d52-8a69-44e0-8287-f645f06ae0fb" />

* [KABUTAN 今日の株価上昇率ランキング (米国株)](https://us.kabutan.jp/warnings/price_increase)
<img width="351" height="394" alt="image" src="https://github.com/user-attachments/assets/eba6dde3-1d23-446c-ad70-269fa2dd012d" />

* [moomoo証券 ランキング (日本株)](https://www.moomoo.com/ja/quote/jp/most-active-stocks)
<img width="389" height="432" alt="image" src="https://github.com/user-attachments/assets/b0af663b-366f-4094-b852-0349350316b2" />

* [moomoo証券 ランキング (米国株)](https://www.moomoo.com/ja/quote/us/most-active-stocks)
<img width="374" height="455" alt="image" src="https://github.com/user-attachments/assets/9cb689f5-b967-48fa-b604-058162b54f32" />

## 関連PR
https://github.com/ogalush/jp_us_stock_extension/pull/8
https://github.com/ogalush/us_stock_extension/pull/8

以上