### PR TITLE
Fix: Peakfinderの銘柄コード列 .sticky-col1 Classによる白色上書き対応 (2026.6)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "日本株/米国株 銘柄チェッカー",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Cleartradeで利用する銘柄チェッカー。日本株/米国株向けです。",
   "icons": {
     "16": "icons/icon16.png",

--- a/siteConfigs.js
+++ b/siteConfigs.js
@@ -12,8 +12,12 @@ window.STOCK_MARKER.SITE_CONFIGS = [
     target: el => el.querySelector("td"),
     applyStyle: (target) => {
       target.style.color = "#000000"; // 黒色 (ダークモード時に白色 vs 黄色(背景)のため指定)
-      target.style.backgroundColor = "#fff3b0"; // 黄色
       target.style.fontWeight = "bold";
+      target.style.setProperty(
+        "background",
+        "#fff3b0",
+        "important"
+      ); // 黄色 (2026.6.23 Peakfinder .sticky-col1 による色上書き対応)
     }
   },
   {


### PR DESCRIPTION
## 概要
2026.6 PeakFinderが改定されたようで、銘柄コード列にCSS `.sticky-col1` Classにより、背景色が白色でimportant指定されていた。
結果として本ツールで銘柄選択した際の背景色黄色の選択が出来ない状態であった。
・変更前の銘柄コード
<img width="298" height="117" alt="image" src="https://github.com/user-attachments/assets/4852cd63-b028-496e-b9d7-a1ec9ea5953f" />

・変更前のCSS
<img width="514" height="807" alt="image" src="https://github.com/user-attachments/assets/b49b5b69-6979-466b-acc6-cdc91d284eb6" />

銘柄コードをマーキングするのはユーザ操作であるため、優先させるために `important` 設定をしてoverrideする。


## 効果
想定通り、important上書きで、意図した通り黄色く表示出来た。
・変更後の銘柄コード
<img width="305" height="140" alt="image" src="https://github.com/user-attachments/assets/176b159f-0a4e-46b4-9306-185a2fd7cf68" />
・変更後のCSS
<img width="537" height="752" alt="image" src="https://github.com/user-attachments/assets/783845b6-6702-4491-883d-b00828455c63" />
